### PR TITLE
Development merge

### DIFF
--- a/app/views/search/preliminary_sentences/_edm.haml
+++ b/app/views/search/preliminary_sentences/_edm.haml
@@ -4,15 +4,20 @@
       %span>= object_display_name_link(object.object_name)
       - unless object.primary_sponsor.blank? && object.other_sponsors.blank?
         %span=" sponsored by "
-      - unless object.primary_sponsor.blank?
-        %span>= search_link(object.primary_sponsor)
-        - unless object.primary_sponsor_party.blank?
-          %span<=" (primary sponsor, "
-          %span>= search_link(object.primary_sponsor_party)
-          %span>=")"
-      - unless object.other_sponsors.blank?
-        %span= render 'search/fragments/edm_sponsor_list', items: object.other_sponsors, terminator: '', singular: false
+      - if object.primary_sponsor.blank?
+        %span= render 'search/fragments/list', items: object.other_sponsors, terminator: '', singular: false
         %span= " and "
+      - else object.primary_sponsor.blank?
+        %span>= search_link(object.primary_sponsor)
+        - if object.primary_sponsor_party.blank?
+          %span=" (primary sponsor) "
+        - else
+          %span=" (primary sponsor, "
+          %span>= search_link(object.primary_sponsor_party)
+          %span=") "
+        - unless object.other_sponsors.blank?
+          %span= render 'search/fragments/edm_sponsor_list', items: object.other_sponsors, terminator: '', singular: false
+          %span= " and "
       %span= " tabled on "
       %strong>= format_date(object.date_tabled)
       %span= ", in the "

--- a/app/views/search/preliminary_sentences/_proceeding_contribution.haml
+++ b/app/views/search/preliminary_sentences/_proceeding_contribution.haml
@@ -18,7 +18,7 @@
       %span= "."
       - unless object.parent_object.blank?
         %span= " It occurred during "
-        %span>= render 'search/fragments/list', items: object.parent_object.object_name, terminator: '', singular: false
+        %span>= render 'search/fragments/list', items: object.parent_object.object_name, terminator: '', singular: true
         %span= " on "
         %span>= object_show_link(object.parent_object.object_title, object.parent_object.object_uri)
         %span= "."


### PR DESCRIPTION
- Singularise proceeding contribution parent proceeding subtypes in sentence
- Use standard list partial for EDM other sponsors if primary sponsor is missing