### PR TITLE
update meta pages

### DIFF
--- a/app/controllers/meta_controller.rb
+++ b/app/controllers/meta_controller.rb
@@ -8,7 +8,7 @@ class MetaController < ApplicationController
   end
 
   def cookies
-    @page_title = 'Cookies'
+    @page_title = 'Cookie Policy'
     @description = 'Cookie Policy.'
     @crumb << { label: 'About this website', url: meta_list_url }
     @crumb << { label: @page_title, url: nil }

--- a/app/controllers/meta_controller.rb
+++ b/app/controllers/meta_controller.rb
@@ -4,7 +4,6 @@ class MetaController < ApplicationController
     @page_title = 'About this website'
     @description = 'About this website.'
     @crumb << { label: @page_title, url: nil }
-    @heading_one = @page_title
   end
 
   def cookies
@@ -12,7 +11,6 @@ class MetaController < ApplicationController
     @description = 'Cookie Policy.'
     @crumb << { label: 'About this website', url: meta_list_url }
     @crumb << { label: @page_title, url: nil }
-    @heading_one = @page_title
 
     render 'library_design/meta/cookies'
   end
@@ -22,7 +20,6 @@ class MetaController < ApplicationController
     @description = 'Coverage.'
     @crumb << { label: 'About this website', url: meta_list_url }
     @crumb << { label: @page_title, url: nil }
-    @heading_one = @page_title
   end
   
   def examples
@@ -30,7 +27,6 @@ class MetaController < ApplicationController
     @description = 'Example object pages.'
     @crumb << { label: 'About this website', url: meta_list_url }
     @crumb << { label: @page_title, url: nil }
-    @heading_one = @page_title
   end
   
   def librarian_tools
@@ -38,7 +34,6 @@ class MetaController < ApplicationController
     @description = 'Librarian tools.'
     @crumb << { label: 'About this website', url: meta_list_url }
     @crumb << { label: @page_title, url: nil }
-    @heading_one = @page_title
   end
 
   def roadmap
@@ -46,7 +41,6 @@ class MetaController < ApplicationController
     @description = 'Roadmap.'
     @crumb << { label: 'About this website', url: meta_list_url }
     @crumb << { label: @page_title, url: nil }
-    @heading_one = @page_title
   end
 
 end

--- a/app/controllers/meta_controller.rb
+++ b/app/controllers/meta_controller.rb
@@ -3,28 +3,50 @@ class MetaController < ApplicationController
   def index
     @page_title = 'About this website'
     @description = 'About this website.'
-    @crumb << { label: 'About this website', url: nil }
+    @crumb << { label: @page_title, url: nil }
+    @heading_one = @page_title
   end
 
   def cookies
     @page_title = 'Cookies'
     @description = 'Cookie Policy.'
-    @crumb << { label: 'Meta', url: meta_list_url }
-    @crumb << { label: 'Cookies', url: nil }
+    @crumb << { label: 'About this website', url: meta_list_url }
+    @crumb << { label: @page_title, url: nil }
+    @heading_one = @page_title
 
     render 'library_design/meta/cookies'
   end
-
+  
+  def coverage
+    @page_title = 'Coverage'
+    @description = 'Coverage.'
+    @crumb << { label: 'About this website', url: meta_list_url }
+    @crumb << { label: @page_title, url: nil }
+    @heading_one = @page_title
+  end
+  
   def examples
-    @page_title = 'Examples'
+    @page_title = 'Example object pages'
+    @description = 'Example object pages.'
+    @crumb << { label: 'About this website', url: meta_list_url }
+    @crumb << { label: @page_title, url: nil }
+    @heading_one = @page_title
+  end
+  
+  def librarian_tools
+    @page_title = 'Librarian tools'
+    @description = 'Librarian tools.'
+    @crumb << { label: 'About this website', url: meta_list_url }
+    @crumb << { label: @page_title, url: nil }
+    @heading_one = @page_title
   end
 
   def roadmap
     @page_title = 'Roadmap'
-  end
-
-  def coverage
-    @page_title = 'Coverage'
+    @description = 'Roadmap.'
+    @crumb << { label: 'About this website', url: meta_list_url }
+    @crumb << { label: @page_title, url: nil }
+    @heading_one = @page_title
   end
 
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,11 @@
 <main id="main-content" class="block block-page">
   <div class="inner-content container">
     <%#= render 'library_design/debug/debug' %>
-	<%= content_tag( 'h1', @heading_one, :class => 'reading-width' ) if @heading_one %>
+    <% if content_for?(:heading) %>
+      <h1 class="reading-width">
+        <%= yield :heading %>
+      </h1>
+    <% end %>
     <%= yield %>
   </div>
 </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
 <main id="main-content" class="block block-page">
   <div class="inner-content container">
     <%#= render 'library_design/debug/debug' %>
+	<%= content_tag( 'h1', @heading_one, :class => 'reading-width' ) if @heading_one %>
     <%= yield %>
   </div>
 </main>

--- a/app/views/layouts/footer/_footer.html.erb
+++ b/app/views/layouts/footer/_footer.html.erb
@@ -1,4 +1,4 @@
 <%= render 'library_design/footer/fat_footer' do %>
 	<%= content_tag( 'li', link_to( 'About this website', meta_list_url ) ) %>
-	<%= content_tag( 'li', link_to( 'Contact us', 'mailto:RIIDMSMailbox@parliament.uk' ) ) %>
+	<%= content_tag( 'li', link_to( 'Contact us', 'mailto:parliamentarysearch@parliament.uk' ) ) %>
 <% end %>

--- a/app/views/meta/coverage.html.erb
+++ b/app/views/meta/coverage.html.erb
@@ -1,0 +1,4 @@
+<div class="reading-width">
+
+	
+</div>

--- a/app/views/meta/coverage.html.erb
+++ b/app/views/meta/coverage.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:heading) do %>
+  <%= @page_title %>
+<% end %>
+
 <div class="reading-width">
 
 	

--- a/app/views/meta/examples.html.erb
+++ b/app/views/meta/examples.html.erb
@@ -1,227 +1,64 @@
-<h1 class="reading-width">Example object pages</h1>
-
-<h2 class='reading-width'>
-  Acts
-</h2>
-<dl class='reading-width'>
-  <dt>Public</dt>
-  <dd>
-    <%= link_to('http://data.parliament.uk/publicgeneralact/2023/19', object_show_url(object: 'http://data.parliament.uk/publicgeneralact/2023/19')) %>
-  </dd>
-  <dt>Private</dt>
-  <dd>
-    <%= link_to('http://data.parliament.uk/localgeneralact/2016/2', object_show_url(object: 'http://data.parliament.uk/localgeneralact/2016/2')) %>
-  </dd>
-</dl>
-
-<h2 class='reading-width'>
-  Bills
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://data.parliament.uk/bills/58255', object_show_url(object: 'http://data.parliament.uk/bills/58255')) %>
-</p>
-
-<h2 class='reading-width'>
-  Church measures
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://data.parliament.uk/churchmeasure/2021/3', object_show_url(object: 'http://data.parliament.uk/churchmeasure/2021/3')) %>
-</p>
-
-<h2 class='reading-width'>
-  Deposited papers
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://data.parliament.uk/depositedpapers/2285506', object_show_url(object: 'http://data.parliament.uk/depositedpapers/2285506')) %>
-</p>
-
-<h2 class='reading-width'>
-  Early day motions
-</h2>
-<dl class='reading-width'>
-  <dd>
-    <%= link_to('http://data.parliament.uk/edms/22468', object_show_url(object: 'http://data.parliament.uk/edms/22468')) %>
-  </dd>
-  <dd>
-    <%= link_to('http://data.parliament.uk/edms/47841', object_show_url(object: 'http://data.parliament.uk/edms/47841')) %>
-  </dd>
-</dl>
-
-<h2 class='reading-width'>
-  Impact assessments
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://data.parliament.uk/pimsdata/ImpactAssessment/13131', object_show_url(object: 'http://data.parliament.uk/pimsdata/ImpactAssessment/13131')) %>
-</p>
-
-<h2 class='reading-width'>
-  Ministerial corrections
-</h2>
-<dl class='reading-width'>
-  <dd>
-    <%= link_to('http://data.parliament.uk/pimsdata/hansard/PROCEEDING_67029', object_show_url(object: 'http://data.parliament.uk/pimsdata/hansard/PROCEEDING_67029')) %>
-  </dd>
-  <dd>
-    <%= link_to('http://hansard.intranet.data.parliament.uk/Commons/2013-12-19/13121970000003', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Commons/2013-12-19/13121970000003')) %>
-  </dd>
-  <dd>
-    <%= link_to('http://hansard.intranet.data.parliament.uk/Commons/2022-12-20/22122049000024', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Commons/2022-12-20/22122049000024')) %>
-  </dd>
-</dl>
-
-<h2 class='reading-width'>
-  Observations on petitions
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://hansard.intranet.data.parliament.uk/Commons/2022-12-19/2212199000020', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Commons/2022-12-19/2212199000020')) %>
-</p>
-
-<h2 class='reading-width'>
-  Oral answers
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://hansard.intranet.data.parliament.uk/Lords/2022-12-21/2212217000022', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Lords/2022-12-21/2212217000022')) %>
-</p>
-
-<h2 class='reading-width'>
-  Oral questions
-</h2>
-<dl class='reading-width'>
-  <dt>Answered</dt>
-  <dd>
-    <%= link_to('http://data.parliament.uk/pimsdata/Hansard/PARLIAMENTARY_QUESTION_366351/-question', object_show_url(object: 'http://data.parliament.uk/pimsdata/Hansard/PARLIAMENTARY_QUESTION_366351/-question')) %>
-  </dd>
-  <dt>Corrected</dt>
-  <dd>
-    <%= link_to('http://hansard.intranet.data.parliament.uk/Lords/2021-05-19/21051926000130', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Lords/2021-05-19/21051926000130')) %>
-  </dd>
-  <dt>Tabled</dt>
-  <dd>
-    <%= link_to('http://tabledpq.indexing.parliament.uk/commons/2015-16/903692', object_show_url(object: 'http://tabledpq.indexing.parliament.uk/commons/2015-16/903692')) %>
-  </dd>
-  <dt>Withdrawn</dt>
-  <dd>
-    <%= link_to('http://tabledpq.indexing.parliament.uk/commons/2022-23/900744', object_show_url(object: 'http://tabledpq.indexing.parliament.uk/commons/2022-23/900744')) %>
-  </dd>
-</dl>
-
-<h2 class='reading-width'>
-  Oral question time interventions
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://data.parliament.uk/pimsdata/hansard/CONTRIBUTION_241033', object_show_url(object: 'http://data.parliament.uk/pimsdata/hansard/CONTRIBUTION_241033')) %>
-</p>
-
-<h2 class='reading-width'>
-  Research briefings
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://data.parliament.uk/resources/1786714', object_show_url(object: 'http://data.parliament.uk/resources/1786714')) %>
-</p>
-
-<h2 class='reading-width'>
-  Papers ordered to be printed
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://data.parliament.uk/papers/64712', object_show_url(object: 'http://data.parliament.uk/papers/64712')) %>
-</p>
-
-<h2 class='reading-width'>
-  Paper petitions
-</h2>
-<dl class="reading-width">
-  <dt>Single member</dt>
-  <dd>
-    <%= link_to('http://hansard.intranet.data.parliament.uk/Commons/2022-12-07/22120755000101', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Commons/2022-12-07/22120755000101')) %>
-  </dd>
-  <dt>Multiple members</dt>
-  <dd>
-    <%= link_to('http://hansard.intranet.data.parliament.uk/Commons/2022-07-13/220713107000568', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Commons/2022-07-13/220713107000568')) %>
-  </dd>
-</dl>
-
-<h2 class='reading-width'>
-  Papers submitted
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://data.parliament.uk/papers/57365', object_show_url(object: 'http://data.parliament.uk/papers/57365')) %>
-</p>
-
-<h2 class='reading-width'>
-  Parliamentary papers
-</h2>
-<dl class='reading-width'>
-  <dt>Laid</dt>
-  <dd>
-    <%= link_to('http://services.paperslaid.parliament.uk/papers/paper/37057', object_show_url(object: 'http://services.paperslaid.parliament.uk/papers/paper/37057')) %>
-  </dd>
-  <dt>Reported</dt>
-  <dd>
-    <%= link_to('http://data.parliament.uk/selectcommittees/54929', object_show_url(object: 'http://data.parliament.uk/selectcommittees/54929')) %>
-  </dd>
-</dl>
-
-<h2 class='reading-width'>
-  Parliamentary proceedings
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://hansard.intranet.data.parliament.uk/Lords/2022-12-21/2212217000100', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Lords/2022-12-21/2212217000100')) %>
-</p>
-
-<h2 class='reading-width'>
-  Proceeding contributions
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://hansard.intranet.data.parliament.uk/Lords/2022-12-21/2212217000041', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Lords/2022-12-21/2212217000041')) %>
-</p>
-
-<h2 class='reading-width'>
-  Statutory instruments
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://paperslaidpoller.parliament.uk/2015-16/2016-05-11/64828', object_show_url(object: 'http://paperslaidpoller.parliament.uk/2015-16/2016-05-11/64828')) %>
-</p>
-
-<h2 class='reading-width'>
-  Transport and works act order applications
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://data.parliament.uk/twas/59276', object_show_url(object: 'http://data.parliament.uk/twas/59276')) %>
-</p>
-
-<h2 class='reading-width'>
-  Written questions
-</h2>
-<dl class='reading-width'>
-  <dt>Answered</dt>
-  <dd>
-    <%= link_to('http://hansard.intranet.data.parliament.uk/Lords/2012-12-10/1212106000156', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Lords/2012-12-10/1212106000156')) %>
-  </dd>
-  <dt>Answered, was holding</dt>
-  <dd>
-    <%= link_to('http://data.parliament.uk/writtenparliamentaryquestion/commons/2015-16/28407', object_show_url(object: 'http://data.parliament.uk/writtenparliamentaryquestion/commons/2015-16/28407')) %>
-  </dd>
-  <dt>Corrected</dt>
-  <dd>
-    <%= link_to('http://data.parliament.uk/pimsdata/Hansard/PARLIAMENTARY_QUESTION_1395367', object_show_url(object: 'http://data.parliament.uk/pimsdata/Hansard/PARLIAMENTARY_QUESTION_1395367')) %>
-  </dd>
-  <dt>Holding</dt>
-  <dd>
-    <%= link_to('http://data.parliament.uk/writtenparliamentaryquestion/commons/2021-22/78384', object_show_url(object: 'http://data.parliament.uk/writtenparliamentaryquestion/commons/2021-22/78384')) %>
-  </dd>
-  <dt>Tabled</dt>
-  <dd>
-    <%= link_to('http://tabledpq.indexing.parliament.uk/commons/2015-16/21659', object_show_url(object: 'http://tabledpq.indexing.parliament.uk/commons/2015-16/21659')) %>
-  </dd>
-  <dt>Withdrawn</dt>
-  <dd>
-    <%= link_to('http://tabledpq.indexing.parliament.uk/commons/2022-23/11562', object_show_url(object: 'http://tabledpq.indexing.parliament.uk/commons/2022-23/11562')) %>
-  </dd>
-</dl>
-
-<h2 class='reading-width'>
-  Written statements
-</h2>
-<p class='reading-width'>
-  <%= link_to('http://hansard.intranet.data.parliament.uk/Commons/2012-12-18/12121863000016', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Commons/2012-12-18/12121863000016')) %>
-</p>
+<div class="reading-width">
+	<%= content_tag( 'p', "Clicking on a result item link in the search results takes the user to an object page. The object page provides more information about that item, including, where available, a link to that item on the web." ) %>
+	
+	<%= content_tag( 'p', "Parliamentary Search includes a range of records of different parliamentary business types. As we've developed the service, we've found it useful to keep a list of examples of the the different types of records available:" ) %>
+	
+	
+	<ol class="unnumbered link-list">
+		<%= content_tag( 'li', link_to( 'Act  – public', object_show_url(object: 'http://data.parliament.uk/publicgeneralact/2023/19' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Act  – private', object_show_url( object: 'http://data.parliament.uk/localgeneralact/2016/2' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Bill', object_show_url( object: 'http://data.parliament.uk/bills/58255' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Church measure', object_show_url( object: 'http://data.parliament.uk/churchmeasure/2021/3' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Deposited paper', object_show_url( object: 'http://data.parliament.uk/depositedpapers/2285506' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Early day motion', object_show_url( object: 'http://data.parliament.uk/localgeneralact/2016/2' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Impact assessment', object_show_url( object: 'http://data.parliament.uk/pimsdata/ImpactAssessment/13131' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Observation on a petition', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Commons/2022-12-19/2212199000020' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Oral answer', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Lords/2022-12-21/2212217000022' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Oral question  – answered', object_show_url( object: 'http://data.parliament.uk/pimsdata/Hansard/PARLIAMENTARY_QUESTION_366351/-question' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Oral question  – corrected', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Lords/2021-05-19/21051926000130' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Oral question  – tabled', object_show_url( object: 'http://tabledpq.indexing.parliament.uk/commons/2015-16/903692' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Oral question  – withdrawn', object_show_url( object: 'http://tabledpq.indexing.parliament.uk/commons/2022-23/900744' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Oral question time intervention', object_show_url( object: 'http://data.parliament.uk/pimsdata/hansard/CONTRIBUTION_241033' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Paper ordered to be printed', object_show_url( object: 'http://data.parliament.uk/papers/64712' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Paper petition  – single member', object_show_url(object: 'http://hansard.intranet.data.parliament.uk/Commons/2022-12-07/22120755000101' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Paper petition  – multiple members', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Commons/2022-07-13/220713107000568' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Parliamentary paper  – laid', object_show_url(object: 'http://services.paperslaid.parliament.uk/papers/paper/37057' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Parliamentary paper  – reported', object_show_url( object: 'http://data.parliament.uk/selectcommittees/54929' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Parliamentary proceeding', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Lords/2022-12-21/2212217000100' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Proceeding contribution', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Lords/2022-12-21/2212217000041' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Research briefing', object_show_url( object: 'http://data.parliament.uk/resources/1786714' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Statutory instrument', object_show_url( object: 'http://paperslaidpoller.parliament.uk/2015-16/2016-05-11/64828' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Transport and Works Act order application', object_show_url( object: 'http://data.parliament.uk/twas/59276' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Written correction – ministerial, to a written answer', object_show_url(object: 'http://data.parliament.uk/correction/commons/2022-23/200877 ' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Written correction – ministerial, to the Official Report', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Commons/2025-11-04/25110457000008' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Written correction – Member, to the Official Report', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Commons/2026-02-04/26020468000024' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Written question – answered', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Lords/2012-12-10/1212106000156' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Written question – answered, previously holding answer', object_show_url( object: 'http://data.parliament.uk/writtenparliamentaryquestion/commons/2015-16/28407' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Written question – corrected answer', object_show_url( object: 'http://data.parliament.uk/pimsdata/Hansard/PARLIAMENTARY_QUESTION_1395367' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Written question – holding answer', object_show_url( object: 'http://data.parliament.uk/writtenparliamentaryquestion/commons/2024-25/15692' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Written question – tabled', object_show_url( object: 'http://tabledpq.indexing.parliament.uk/commons/2015-16/21659' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Written question – withdrawn', object_show_url( object: 'http://tabledpq.indexing.parliament.uk/commons/2022-23/11562' ) ) ) %>
+		
+		<%= content_tag( 'li', link_to( 'Written statement', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Commons/2012-12-18/12121863000016' ) ) ) %>
+	</ol>
+</div>

--- a/app/views/meta/examples.html.erb
+++ b/app/views/meta/examples.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:heading) do %>
+	<%= @page_title %>
+<% end %>
+
 <div class="reading-width">
 	<%= content_tag( 'p', "Clicking on a result item link in the search results takes the user to an object page. The object page provides more information about that item, including, where available, a link to that item on the web." ) %>
 	

--- a/app/views/meta/index.html.erb
+++ b/app/views/meta/index.html.erb
@@ -1,0 +1,9 @@
+<div class="reading-width">
+	<ol class="unnumbered link-list">
+		<%= content_tag( 'li', link_to( 'Cookies', meta_cookies_url ) ) %>
+		<%= content_tag( 'li', link_to( 'Coverage', meta_coverage_url ) ) %>
+		<%= content_tag( 'li', link_to( 'Example object pages', meta_examples_url ) ) %>
+		<%= content_tag( 'li', link_to( 'Librarian tools', meta_librarian_tools_url ) ) %>
+		<%= content_tag( 'li', link_to( 'Roadmap', meta_roadmap_url ) ) %>
+	</ol>
+</div>

--- a/app/views/meta/index.html.erb
+++ b/app/views/meta/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:heading) do %>
+	<%= @page_title %>
+<% end %>
+
 <div class="reading-width">
 	<ol class="unnumbered link-list">
 		<%= content_tag( 'li', link_to( 'Cookies', meta_cookies_url ) ) %>

--- a/app/views/meta/librarian_tools.html.erb
+++ b/app/views/meta/librarian_tools.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:heading) do %>
+	<%= @page_title %>
+<% end %>
+
 <div class="reading-width">
 	<%= content_tag( 'p', "Parliamentary Search contains a built in feature to help our team debug the application. This includes information about what was actually searched for and links to source systems." ) %>
 

--- a/app/views/meta/librarian_tools.html.erb
+++ b/app/views/meta/librarian_tools.html.erb
@@ -1,0 +1,19 @@
+<div class="reading-width">
+	<%= content_tag( 'p', "Parliamentary Search contains a built in feature to help our team debug the application. This includes information about what was actually searched for and links to source systems." ) %>
+
+	<%= content_tag( 'p', "Librarian tools are available from both search result pages and object pages." ) %>
+
+	<%= content_tag( 'p', "To access librarian tools, users on a Windows PC need to press:" ) %>
+
+	<p>
+		<%= content_tag( 'code', "Ctrl, Alt + D" ) %>
+	</p>
+
+	<%= content_tag( 'p', "Mac users need to press:" ) %>
+
+	<p>
+		<%= content_tag( 'code', "Control, Option + D" ) %>
+	</p>
+
+	<%= content_tag( 'p', "Some links shown by librarian tools only work for users on the parliamentary network." ) %>
+</div>

--- a/app/views/meta/roadmap.html.erb
+++ b/app/views/meta/roadmap.html.erb
@@ -1,0 +1,10 @@
+<div class="reading-width">
+
+	<%= content_tag( 'p', "We are currently focussed on improving how Parliamentary Search handles queries.".html_safe ) %>
+
+	<%= content_tag( 'p', "Once that work has been tested, we plan to work on an advanced search form, then the functionality to export search results as a spreadsheet." ) %>
+	
+	<%= content_tag( 'p', "More details of planned work can be found on our public #{link_to( 'Trello board', 'https://trello.com/b/hP5FLFHA/search-application-development' )}.".html_safe ) %>
+	
+	<%= content_tag( 'p', "The #{link_to( 'website code can be found on GitHub', 'https://github.com/ukparliament/search-prototype' )}. Pull requests are welcome.".html_safe ) %>
+</div>

--- a/app/views/meta/roadmap.html.erb
+++ b/app/views/meta/roadmap.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:heading) do %>
+	<%= @page_title %>
+<% end %>
+
 <div class="reading-width">
 
 	<%= content_tag( 'p', "We are currently focussed on improving how Parliamentary Search handles queries.".html_safe ) %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -6,7 +6,7 @@
 
 <div class="row">
   <div class="col reading-width">
-    <%= content_tag( 'h2', 'Welcome to Parliamentary Search' ) %>
+    <%= content_tag( 'h1', 'Welcome to Parliamentary Search' ) %>
 	  <%= content_tag( 'p', "We're working on a replacement for #{link_to( 'Parliamentary Search', 'https://search.parliament.uk/search' )}, available to users on the Parliamentary network - and #{link_to( 'Search Parliamentary Material', 'https://search-material.parliament.uk/' )}, the public-facing version of Parliamentary Search.".html_safe ) %>
 	  
 	  <%= content_tag( 'h2', 'What you can find here' ) %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,18 +1,18 @@
-<%= render '/shared/search_bar' %>
+<div class="row">
+	<div class="col reading-width">
+		<%= render '/shared/search_bar' %>
+	</div>
+</div>
 
 <div class="row">
   <div class="col reading-width">
-    <h2>About this website</h2>
-    <p>This website is under development and may be unavailable at times.</p>
-    <p>We're working on a replacement
-      for <%= link_to 'Parliamentary Search', 'https://search.parliament.uk/search' %>
-      (available to users on the Parliamentary network)
-      and <%= link_to 'Search Parliamentary Material', 'https://search-material.parliament.uk/' %> (the
-      public-facing
-      version of Parliamentary Search).</p>
-    <p>Details of what we are working on can be found on
-      our <%= link_to 'Trello Board', 'https://trello.com/b/hP5FLFHA/search-frontend' %>.</p>
-    <p>You can reach the team
-      at <%= link_to 'parliamentarysearch@parliament.uk', 'mailto:parliamentarysearch@parliament.uk' %>.</p>
-  </div>
+    <%= content_tag( 'h2', 'Welcome to Parliamentary Search' ) %>
+	  <%= content_tag( 'p', "We're working on a replacement for #{link_to( 'Parliamentary Search', 'https://search.parliament.uk/search' )}, available to users on the Parliamentary network - and #{link_to( 'Search Parliamentary Material', 'https://search-material.parliament.uk/' )}, the public-facing version of Parliamentary Search.".html_safe ) %>
+	  
+	  <%= content_tag( 'h2', 'What you can find here' ) %>
+	  <%= content_tag( 'p', 'You can use Parliamentary Search to find records of parliamentary business and research briefings, from both Houses, in one place. Parliamentary Search has its own database, containing information dating back to the early 1990s and in some cases earlier. It is the only public service where this range of parliamentary data can be found in one place.' ) %>
+	  <%= content_tag( 'p', 'Material in Parliamentary Search is subject indexed, which means the search is more powerful than a simple keyword search. It is interlinked, which means you can get from the written question about a bill to the actual bill, or from a Minister’s commitment to deposit a letter in the Library, to that letter.' ) %>
+	  <%= content_tag( 'p', content_tag( 'em', 'This website is under development and may be unavailable at times.' ) ) %>
+	  <%= content_tag( 'p', "You can reach the team at #{link_to 'parliamentarysearch@parliament.uk', 'mailto:parliamentarysearch@parliament.uk'}.".html_safe ) %>
+	</div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,10 @@ Rails.application.routes.draw do
   get 'errors/404' => 'errors#not_found'
   get 'errors/401' => 'errors#not_authorized'
 
-  get 'meta/examples' => 'meta#examples', as: :meta_examples
   get 'meta' => 'meta#index', as: :meta_list
   get 'meta/cookies' => 'meta#cookies', as: :meta_cookies
   get 'meta/coverage' => 'meta#coverage', as: :meta_coverage
+  get 'meta/examples' => 'meta#examples', as: :meta_examples
+  get 'meta/librarian-tools' => 'meta#librarian_tools', as: :meta_librarian_tools
   get 'meta/roadmap' => 'meta#roadmap', as: :meta_roadmap
 end


### PR DESCRIPTION
- **added optional h1 derived from @heading_one to application template**
- **constructed meta crumbs and added @heading_one for h1 display**
- **filled out meta list**
- **fixed email link in footer**
- **edited homepage text**
- **updated cookie page title**
- **first attempt at a tools page**
- **first draft examples objects text**
- **first draft of roadmap page text**
- **added route for librarian tools under meta**
- **stripped out coerage text for now**
