### PR TITLE
text tweaks on meta pages

### DIFF
--- a/app/views/meta/coverage.html.erb
+++ b/app/views/meta/coverage.html.erb
@@ -3,6 +3,5 @@
 <% end %>
 
 <div class="reading-width">
-
-	
+	<%= content_tag( 'p', 'Coming soon.' ) %>
 </div>

--- a/app/views/meta/examples.html.erb
+++ b/app/views/meta/examples.html.erb
@@ -5,7 +5,7 @@
 <div class="reading-width">
 	<%= content_tag( 'p', "Clicking on a result item link in the search results takes the user to an object page. The object page provides more information about that item, including, where available, a link to that item on the web." ) %>
 	
-	<%= content_tag( 'p', "Parliamentary Search includes a range of records of different parliamentary business types. As we've developed the service, we've found it useful to keep a list of examples of the the different types of records available:" ) %>
+	<%= content_tag( 'p', "Parliamentary Search includes a range of records of different parliamentary business types. As we've developed the service, we've found it useful to keep a list of examples of the different types of records available:" ) %>
 	
 	
 	<ol class="unnumbered link-list">
@@ -27,12 +27,12 @@
 		
 		<%= content_tag( 'li', link_to( 'Oral answer', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Lords/2022-12-21/2212217000022' ) ) ) %>
 		
-		<%= content_tag( 'li', link_to( 'Oral question  – answered', object_show_url( object: 'http://data.parliament.uk/pimsdata/Hansard/PARLIAMENTARY_QUESTION_366351/-question' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Oral question  – answered', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Lords/2023-12-18/23121826000056' ) ) ) %>
 		<%= content_tag( 'li', link_to( 'Oral question  – corrected', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Lords/2021-05-19/21051926000130' ) ) ) %>
 		<%= content_tag( 'li', link_to( 'Oral question  – tabled', object_show_url( object: 'http://tabledpq.indexing.parliament.uk/commons/2015-16/903692' ) ) ) %>
 		<%= content_tag( 'li', link_to( 'Oral question  – withdrawn', object_show_url( object: 'http://tabledpq.indexing.parliament.uk/commons/2022-23/900744' ) ) ) %>
 		
-		<%= content_tag( 'li', link_to( 'Oral question time intervention', object_show_url( object: 'http://data.parliament.uk/pimsdata/hansard/CONTRIBUTION_241033' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Oral question time intervention', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Commons/2019-03-19/19031947000220' ) ) ) %>
 		
 		<%= content_tag( 'li', link_to( 'Paper ordered to be printed', object_show_url( object: 'http://data.parliament.uk/papers/64712' ) ) ) %>
 		
@@ -52,7 +52,7 @@
 		
 		<%= content_tag( 'li', link_to( 'Transport and Works Act order application', object_show_url( object: 'http://data.parliament.uk/twas/59276' ) ) ) %>
 		
-		<%= content_tag( 'li', link_to( 'Written correction – ministerial, to a written answer', object_show_url(object: 'http://data.parliament.uk/correction/commons/2022-23/200877 ' ) ) ) %>
+		<%= content_tag( 'li', link_to( 'Written correction – ministerial, to a written answer', object_show_url(object: 'http://data.parliament.uk/correction/commons/2022-23/200877' ) ) ) %>
 		<%= content_tag( 'li', link_to( 'Written correction – ministerial, to the Official Report', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Commons/2025-11-04/25110457000008' ) ) ) %>
 		<%= content_tag( 'li', link_to( 'Written correction – Member, to the Official Report', object_show_url( object: 'http://hansard.intranet.data.parliament.uk/Commons/2026-02-04/26020468000024' ) ) ) %>
 		

--- a/app/views/meta/index.html.erb
+++ b/app/views/meta/index.html.erb
@@ -4,7 +4,7 @@
 
 <div class="reading-width">
 	<ol class="unnumbered link-list">
-		<%= content_tag( 'li', link_to( 'Cookies', meta_cookies_url ) ) %>
+		<%= content_tag( 'li', link_to( 'Cookie Policy', meta_cookies_url ) ) %>
 		<%= content_tag( 'li', link_to( 'Coverage', meta_coverage_url ) ) %>
 		<%= content_tag( 'li', link_to( 'Example object pages', meta_examples_url ) ) %>
 		<%= content_tag( 'li', link_to( 'Librarian tools', meta_librarian_tools_url ) ) %>

--- a/app/views/meta/librarian_tools.html.erb
+++ b/app/views/meta/librarian_tools.html.erb
@@ -19,5 +19,5 @@
 		<%= content_tag( 'code', "Control, Option + D" ) %>
 	</p>
 
-	<%= content_tag( 'p', "Some links shown by librarian tools only work for users on the parliamentary network." ) %>
+	<%= content_tag( 'p', "Not all the links shown by librarian tools will work for all users. The link to Solr will only work for users on the parliamentary network with a subscription key. The Indexing link will only work for users on the parliamentary network with access to the Indexing Tool." ) %>
 </div>


### PR DESCRIPTION
- **link to cookies now Cookie Policy**
- **added coming soon to coverage meta page**
- **fixed typo, linked to better examples**
- **clarified which links won't work for all users from librarian tools meta page**
