### PR TITLE
Format @page_title and @crumb for object pages using format_object_title helper method 

### DIFF
--- a/app/controllers/content_type_objects_controller.rb
+++ b/app/controllers/content_type_objects_controller.rb
@@ -22,8 +22,9 @@ class ContentTypeObjectsController < ApplicationController
     # Use SesData class to handle SES retrival from cache / API
     @ses_data = SesData.new(all_ses_ids).combined_ses_data
 
-    @page_title = "#{@object.object_title}"
-    @crumb << { label: @object.object_title, url: nil }
+    formatted_object_title = helpers.format_object_title(@object.object_title, @ses_data)
+    @page_title = formatted_object_title
+    @crumb << { label: formatted_object_title, url: nil }
 
     render template: @object.template, :locals => { :object => @object }
   end


### PR DESCRIPTION
Most object pages use page_title as their title, which is taken from title_t. For objects where this isn't populated, we're falling back to the subtype, then the type. For the headings on the object pages, we're already using a helper method to format this data for presentation. This change employs that same helper method when setting the variables @page_title (used for browser tab labels etc.) and @crumb (used for design system breadcrumb labels) so that objects without title_t are no longer showing the underlying data hash in these places.