### PR TITLE
Blockquote styling

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -52,3 +52,27 @@ p {
 .wrap-anywhere {
     overflow-wrap: anywhere;
 }
+
+/* Styling for blockquotes */
+
+blockquote {
+    position: relative;
+    margin: 1rem;
+    padding-left: 2rem;
+    font-size: 1.25rem;
+}
+
+blockquote::before {
+    content: open-quote;
+    position: absolute;
+    left: 0.5rem;
+    top: -0.1rem;
+    font-size: 3rem;
+    line-height: 1;
+    color: #717171;
+}
+
+blockquote p:last-of-type:after {
+    content: close-quote;
+    color: #717171;
+}


### PR DESCRIPTION
Add styling for blockquotes (inspired by HoC Library research briefings, where it seems to be included in the Design System?)

<img width="1302" height="1068" alt="image" src="https://github.com/user-attachments/assets/3dfb4534-a7c6-4ad0-9c73-e25b01e49689" />