### PR TITLE
Add direct link to download research briefing file

### DIFF
--- a/app/models/research_briefing.rb
+++ b/app/models/research_briefing.rb
@@ -82,4 +82,14 @@ class ResearchBriefing < ContentTypeObject
   def last_updated
     get_first_as_date_from('modified_dt')
   end
+
+  def file_location
+    uris = get_all_from('contentLocation_uri')
+    return if uris.blank?
+
+    uris.map do |uri|
+      full = URI.parse(uri[:value])
+      URI::HTTPS.build(host: full.host, path: full.path)
+    end
+  end
 end

--- a/app/views/content_type_objects/object_pages/research_briefing.html.erb
+++ b/app/views/content_type_objects/object_pages/research_briefing.html.erb
@@ -17,6 +17,19 @@
   </div>
 <% end %>
 
+<% unless object.file_location.blank? %>
+  <section class="reading-width">
+    <dl class="reading-width">
+      <dt>Download full report</dt>
+      <% object.file_location.each do |uri| %>
+        <dd>
+          <%= link_to(uri, uri.to_s) %>
+        </dd>
+      <% end %>
+    </dl>
+  </section>
+<% end %>
+
 <section class="reading-width">
   <hr/>
   <h2>Secondary information</h2>

--- a/app/views/content_type_objects/object_pages/research_briefing.html.erb
+++ b/app/views/content_type_objects/object_pages/research_briefing.html.erb
@@ -18,16 +18,9 @@
 <% end %>
 
 <% unless object.file_location.blank? %>
-  <section class="reading-width">
-    <dl class="reading-width">
-      <dt>Download full report</dt>
-      <% object.file_location.each do |uri| %>
-        <dd>
-          <%= link_to(uri, uri.to_s) %>
-        </dd>
-      <% end %>
-    </dl>
-  </section>
+  <p class="reading-width">
+    <%= link_to("Download full report", object.file_location.to_s) %>
+  </p>
 <% end %>
 
 <section class="reading-width">

--- a/spec/models/research_briefing_spec.rb
+++ b/spec/models/research_briefing_spec.rb
@@ -380,4 +380,27 @@ RSpec.describe ResearchBriefing, type: :model do
       end
     end
   end
+
+  describe 'file_location' do
+    context 'where there is no data' do
+      it 'returns nil' do
+        expect(research_briefing.file_location).to be_nil
+      end
+    end
+
+    context 'where there is an empty array' do
+      let!(:research_briefing) { ResearchBriefing.new({ 'contentLocation_uri' => [] }) }
+      it 'returns nil' do
+        expect(research_briefing.file_location).to be_nil
+      end
+    end
+
+    context 'where data exists' do
+      let!(:research_briefing) { ResearchBriefing.new({ 'contentLocation_uri' => ['http://www.test1.com', 'https://www.test2.com'] }) }
+
+      it 'returns an array of HTTPS URIs' do
+        expect(research_briefing.file_location.map(&:to_s)).to eq(['https://www.test1.com', 'https://www.test2.com'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds a 'download full report' link to the end of the research briefing text, which links to contentLocation_uri, if present. 