### PR TITLE
Searchable category_ses (via type alias) for research briefings

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -3,6 +3,7 @@ module LinkHelper
     answeringDept_ses
     answeringMember_ses
     askingMember_ses
+    category_ses
     department_ses
     leadMember_ses
     legislationTitle_ses
@@ -67,7 +68,7 @@ module LinkHelper
     return 'primarysponsor' if ['primarySponsor_ses'].include?(field_name)
     return 'publisher' if ['publisher_ses'].include?(field_name)
     return 'subject' if ['subject_ses', 'subject_t'].include?(field_name)
-    return 'type' if ['subtype_ses', 'type_ses'].include?(field_name)
+    return 'type' if ['subtype_ses', 'type_ses', 'category_ses'].include?(field_name)
     return 'tabledby' if ['tablingMember_ses'].include?(field_name)
 
     field_name

--- a/app/models/research_briefing.rb
+++ b/app/models/research_briefing.rb
@@ -51,10 +51,6 @@ class ResearchBriefing < ContentTypeObject
     combine_fields(creators, contributors)
   end
 
-  def series
-    get_first_from('category_ses')
-  end
-
   def category
     get_first_from('category_ses')
   end

--- a/app/views/content_type_objects/fragments/_category.html.erb
+++ b/app/views/content_type_objects/fragments/_category.html.erb
@@ -1,0 +1,8 @@
+<% unless category.blank? %>
+  <dt>
+    Category
+  </dt>
+  <dd>
+    <%= search_link(category) %>
+  </dd>
+<% end %>

--- a/app/views/content_type_objects/fragments/_series.html.erb
+++ b/app/views/content_type_objects/fragments/_series.html.erb
@@ -1,8 +1,0 @@
-<% unless series.blank? %>
-  <dt>
-    Series
-  </dt>
-  <dd>
-    <%= search_link(series) %>
-  </dd>
-<% end %>

--- a/app/views/content_type_objects/object_pages/research_briefing.html.erb
+++ b/app/views/content_type_objects/object_pages/research_briefing.html.erb
@@ -1,7 +1,7 @@
 <% if Rails.env.development? %>
   <div class="debug-panel" aria-hidden="true">
-    <%#= render 'content_type_objects/fragments/data', data: object.content_type_object_data, title: 'SOLR Data' %>
-    <%#= render 'content_type_objects/fragments/data', data: @ses_data, title: 'SES Data' %>
+    <%= render 'content_type_objects/fragments/data', data: object.content_type_object_data, title: 'SOLR Data' %>
+    <%= render 'content_type_objects/fragments/data', data: @ses_data, title: 'SES Data' %>
   </div>
 <% end %>
 
@@ -23,7 +23,7 @@
   <dl>
     <%= render 'content_type_objects/fragments/type', type: object.type %>
     <%= render 'content_type_objects/fragments/reference', reference: object.reference %>
-    <%= render 'content_type_objects/fragments/series', series: object.series %>
+    <%= render 'content_type_objects/fragments/category', category: object.category %>
     <%= render 'content_type_objects/fragments/related_items', related_item_ids: object.related_item_ids %>
     <%= render 'content_type_objects/fragments/notes', notes: object.notes %>
     <%= render 'content_type_objects/fragments/pills', pills_heading: 'Subjects', pills: object.subjects %>


### PR DESCRIPTION
Research Briefings now have click-through search links based on category_ses, which operate using the type alias: 
- Add category_ses to SEARCH_LINK_FIELD_NAMES (enables click-through search links for this field)
- Add category_ses to type alias
- Remove 'series' from research_briefing (we already had a category method for category_ses)
- Rename series partial -> category & update references & label for object page display