### PR TITLE
Use answering department in written question sentences

### DIFF
--- a/app/views/content_type_objects/preliminary_sentences/_written_question_answered.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_written_question_answered.haml
@@ -34,9 +34,9 @@
   - unless object.date_of_answer.blank?
     %span= " on "
     %span>= format_date(object.date_of_answer)
-  - unless object.department.blank?
+  - unless object.answering_department.blank?
     %span= " on behalf of the "
-    %span>= search_link(object.department)
+    %span>= search_link(object.answering_department)
   %span= "."
   - unless object.asked_to_reply_author.blank?
     %span= search_link(object.asked_to_reply_author)

--- a/app/views/content_type_objects/preliminary_sentences/_written_question_answered_was_holding.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_written_question_answered_was_holding.haml
@@ -39,9 +39,9 @@
         %span= ") "
     %span= " on "
     %span>= format_date(object.date_of_answer)
-    - unless object.department.blank?
+    - unless object.answering_department.blank?
       %span= " on behalf of the "
-      %span>= search_link(object.department)
+      %span>= search_link(object.answering_department)
     %span= "."
     - unless object.asked_to_reply_author.blank?
       %span= search_link(object.asked_to_reply_author)

--- a/app/views/content_type_objects/preliminary_sentences/_written_question_corrected.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_written_question_corrected.haml
@@ -34,9 +34,9 @@
   - unless object.date_of_answer.blank?
     %span= " on "
     %span>= format_date(object.date_of_answer)
-  - unless object.department.blank?
+  - unless object.answering_department.blank?
     %span= " on behalf of the "
-    %span>= search_link(object.department)
+    %span>= search_link(object.answering_department)
   %span= "."
   - unless object.asked_to_reply_author.blank?
     %span= search_link(object.asked_to_reply_author)

--- a/app/views/content_type_objects/preliminary_sentences/_written_question_holding.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_written_question_holding.haml
@@ -34,7 +34,7 @@
         %span= ") "
     %span= " on "
     %span>= format_date(object.date_of_holding_answer)
-    - unless object.department.blank?
+    - unless object.answering_department.blank?
       %span= " on behalf of the "
-      %span>= search_link(object.department)
+      %span>= search_link(object.answering_department)
     %span= "."

--- a/app/views/content_type_objects/preliminary_sentences/_written_question_withdrawn.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_written_question_withdrawn.haml
@@ -17,9 +17,9 @@
     %span>= render 'content_type_objects/fragments/list', items: object.legislature, terminator: '', singular: false
   %span>= "."
   %span>= " The member has subsequently withdrawn this question"
-  - if object.department.blank?
+  - if object.answering_department.blank?
     %span>= " and it no longer needs to be answered"
   - else
     %span= ". An answer is no longer expected from the "
-    %span>= search_link(object.department)
+    %span>= search_link(object.answering_department)
   %span= "."


### PR DESCRIPTION
- Use answering_department (answeringDept_ses) on written question sentences instead of department (department_ses). This also changes the alias used for the search link from dept to answeredby.