### PR TITLE
Raise a 404 for bad object data

### DIFF
--- a/app/controllers/content_type_objects_controller.rb
+++ b/app/controllers/content_type_objects_controller.rb
@@ -7,6 +7,9 @@ class ContentTypeObjectsController < ApplicationController
     # construct the object
     @object = ContentTypeObject.generate(object_data)
 
+    # raise a 404 if we didn't successfully generate an object
+    raise ExternalServiceNotFound unless @object
+
     # check the object is supported
     raise ObjectNotSupported if @object.is_a?(NotSupported)
 

--- a/app/errors/object_not_found.rb
+++ b/app/errors/object_not_found.rb
@@ -1,0 +1,1 @@
+class ObjectNotFound < StandardError; end

--- a/app/models/content_type_object.rb
+++ b/app/models/content_type_object.rb
@@ -6,8 +6,11 @@ class ContentTypeObject
     @content_type_object_data = content_type_object_data
   end
 
+  ##
+  # takes object data as an argument and returns an instance of the correct object subclass
   def self.generate(content_type_object_data)
-    # takes object data as an argument and returns an instance of the correct object subclass
+    # return nil if there's no data
+    return unless content_type_object_data
 
     type_id = content_type_object_data.dig('type_ses', 0)
     subtype_ids = content_type_object_data.dig('subtype_ses')

--- a/app/services/associated_objects.rb
+++ b/app/services/associated_objects.rb
@@ -8,7 +8,7 @@ class AssociatedObjects
   end
 
   def associated_object_ids
-    @associated_object_ids ||= normalised_objects.map { |o| o.associated_objects }.compact.flatten.uniq
+    @associated_object_ids ||= normalised_objects.map { |o| o&.associated_objects }.compact.flatten.uniq
   end
 
   def get_associated_objects

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,7 @@ module Search
 
     # Assign error codes to custom errors
     config.action_dispatch.rescue_responses["ObjectNotSupported"] = :not_found
+    config.action_dispatch.rescue_responses["ObjectNotFound"] = :not_found
     config.action_dispatch.rescue_responses["ExternalServiceNotFound"] = :not_found
     config.action_dispatch.rescue_responses["ExternalServiceUnauthorized"] = :forbidden
   end

--- a/spec/requests/content_type_objects_spec.rb
+++ b/spec/requests/content_type_objects_spec.rb
@@ -2,9 +2,21 @@ require 'rails_helper'
 
 RSpec.describe 'ContentTypeObjects', type: :request do
   describe 'GET /show' do
-    let!(:edm_instance) { Edm.new('test') }
+
+    context 'no data' do
+      let!(:no_data) { nil }
+
+      it 'raises a 404 error' do
+        allow_any_instance_of(SolrQuery).to receive(:all_data).and_return({ 'response' => { "docs" => [{ 'type_ses' => [12345] }] } })
+        allow_any_instance_of(SesLookup).to receive(:data).and_return({})
+        allow(ContentTypeObject).to receive(:generate).and_return(no_data)
+        get '/objects', params: { :object => 'test_string' }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
 
     context 'success' do
+      let!(:edm_instance) { Edm.new('test') }
       it 'returns http success' do
         allow_any_instance_of(SolrQuery).to receive(:all_data).and_return({ 'response' => { "docs" => [{ 'type_ses' => [12345] }] } })
         allow_any_instance_of(SesLookup).to receive(:data).and_return({})


### PR DESCRIPTION
- Attempting to load the object page without a valid ID now correctly returns a 404