### PR TITLE
Fix for errors loading certain object types

### DIFF
--- a/app/models/content_type_object.rb
+++ b/app/models/content_type_object.rb
@@ -465,8 +465,6 @@ class ContentTypeObject
 
   def self.content_type_object_class(type_id, subtype_ids)
     case type_id
-    when 363376
-      'ResearchMaterial'
     when 90996
       'Edm'
     when 346697
@@ -554,16 +552,6 @@ class ContentTypeObject
       'ParliamentaryProceeding'
     when 347226
       'StatutoryInstrument'
-    when 347028
-      'EuropeanDepositedDocument'
-    when 347036
-      'EuropeanScrutinyExplanatoryMemorandum'
-    when 347040
-      'EuropeanScrutinyMinisterialCorrespondence'
-    when 347032
-      'EuropeanScrutinyRecommendation'
-    when 347010
-      'EuropeanMaterial'
     else
       'NotSupported'
     end

--- a/app/views/content_type_objects/object_pages/command_paper.html.erb
+++ b/app/views/content_type_objects/object_pages/command_paper.html.erb
@@ -1,0 +1,52 @@
+<% if Rails.env.development? %>
+  <div class="debug-panel" aria-hidden="true">
+    <%#= render 'content_type_objects/fragments/data', data: object.content_type_object_data, title: 'SOLR Data' %>
+    <%#= render 'content_type_objects/fragments/data', data: @ses_data, title: 'SES Data' %>
+  </div>
+<% end %>
+
+<%= render object.prelim_template, object: object %>
+<h1 class="reading-width">
+  <hr/>
+  <%= format_object_title(object.object_title, @ses_data) %>
+</h1>
+
+<% unless object.abstract_text.blank? %>
+  <p class="reading-width">
+    <%= object.abstract_text[:value] %>
+  </p>
+<% end %>
+
+<section class="reading-width">
+  <hr/>
+  <h2>Secondary information</h2>
+  <dl>
+    <%= render 'content_type_objects/fragments/type', type: object.type %>
+    <%= render 'content_type_objects/fragments/reference', reference: object.reference %>
+    <%= render 'content_type_objects/fragments/session', session: object.parliamentary_session %>
+    <%= render 'content_type_objects/fragments/coming_into_force', notes: object.coming_into_force, date: object.coming_into_force_date %>
+    <%= render 'content_type_objects/fragments/corporate_author', author_label: 'Author', author: object.corporate_author %>
+    <%= render 'content_type_objects/fragments/paper_type', paper_type: object.paper_type %>
+    <%= render 'content_type_objects/fragments/paper_procedure', procedure: object.paper_procedure, approval_days: object.procedure_scrutiny_period %>
+    <%= render 'content_type_objects/fragments/laying_authority', laying_authority: object.laying_authority %>
+    <%= render 'content_type_objects/fragments/laid_in_draft', laid_in_draft: object.is_laid_in_draft %>
+    <%= render 'content_type_objects/fragments/certified_categories', certified_categories: object.certified_categories, certified_date: object.certified_date %>
+    <%= render 'content_type_objects/fragments/referred_to', referred_to: object.referred_to %>
+    <%= render 'content_type_objects/fragments/considered_by_eu_si_committee', considered: object.is_considered_by_eu_si_committee %>
+    <%= render 'content_type_objects/fragments/considered_by_secondary_legislation_committee', considered: object.is_considered_by_secondary_legislation_committee %>
+    <%= render 'content_type_objects/fragments/reported_by_joint_committee', reported: object.is_reported_by_joint_committee %>
+    <%= render 'content_type_objects/fragments/related_items', related_item_ids: object.related_item_ids %>
+    <%= render 'content_type_objects/fragments/ec_documents', ec_documents: object.ec_documents %>
+    <%= render 'content_type_objects/fragments/contains_explanatory_memorandum', contains_em: object.contains_explanatory_memo %>
+    <%= render 'content_type_objects/fragments/contains_impact_assessment', contains_ia: object.contains_impact_assessment %>
+    <%= render 'content_type_objects/fragments/notes', notes: object.notes %>
+    <%= render 'content_type_objects/fragments/pills', pills_heading: 'Subjects', pills: object.subjects %>
+    <%= render 'content_type_objects/fragments/legislation', legislation: object.legislation %>
+    <%= render 'content_type_objects/fragments/library_location', commons: object.commons_library_location, lords: object.lords_library_location %>
+    <%= render 'content_type_objects/fragments/contains_statistics', contains_statistics: object.contains_statistics %>
+    <%= render 'content_type_objects/fragments/isbn', isbn: object.isbn %>
+    <%= render 'content_type_objects/fragments/link', object: object %>
+  </dl>
+</section>
+
+<%= render '/content_type_objects/fragments/about_this_result', object: object %>

--- a/app/views/content_type_objects/object_pages/committee_proceeding.html.erb
+++ b/app/views/content_type_objects/object_pages/committee_proceeding.html.erb
@@ -1,0 +1,44 @@
+<% if Rails.env.development? %>
+  <div class="debug-panel" aria-hidden="true">
+    <%#= render 'content_type_objects/fragments/data', data: object.content_type_object_data, title: 'SOLR Data' %>
+    <%#= render 'content_type_objects/fragments/data', data: @ses_data, title: 'SES Data' %>
+  </div>
+<% end %>
+
+<%= render object.prelim_template, object: object %>
+<h1 class="reading-width">
+  <hr/>
+  <%= format_object_title(object.object_title, @ses_data) %>
+</h1>
+
+<% unless object.abstract_text.blank? %>
+  <div class="reading-width">
+    <%= raw format_html(object.abstract_text[:value], false) %>
+  </div>
+<% end %>
+
+<section class="reading-width">
+  <hr/>
+  <h2>Secondary information</h2>
+  <dl>
+    <%= render 'content_type_objects/fragments/type', type: object.type %>
+    <%= render 'content_type_objects/fragments/reference', reference: object.reference %>
+    <%= render 'content_type_objects/fragments/session', session: object.parliamentary_session %>
+    <%= render 'content_type_objects/fragments/departments', departments: object.departments %>
+    <%= render 'content_type_objects/fragments/corporate_author', author_label: 'Committee', author: object.corporate_author %>
+    <%= render 'content_type_objects/fragments/witnesses', witnesses: object.witnesses %>
+    <%= render 'content_type_objects/fragments/legislative_stage', legislative_stage: object.legislative_stage %>
+    <%= render 'content_type_objects/fragments/procedure', procedure: object.procedure %>
+    <%= render 'content_type_objects/fragments/place', place: object.place %>
+    <%= render 'content_type_objects/fragments/related_items', related_item_ids: object.related_item_ids %>
+    <%= render 'content_type_objects/fragments/contributions', contribution_ids: object.contribution_ids %>
+    <%= render 'content_type_objects/fragments/ec_documents', ec_documents: object.ec_documents %>
+    <%= render 'content_type_objects/fragments/notes', notes: object.notes %>
+    <%= render 'content_type_objects/fragments/pills', pills_heading: 'Subjects', pills: object.subjects %>
+    <%= render 'content_type_objects/fragments/legislation', legislation: object.legislation %>
+    <%= render 'content_type_objects/fragments/contains_statistics', contains_statistics: object.contains_statistics %>
+    <%= render 'content_type_objects/fragments/link', object: object %>
+  </dl>
+</section>
+
+<%= render '/content_type_objects/fragments/about_this_result', object: object %>

--- a/app/views/content_type_objects/object_pages/grand_committee_proceeding.html.erb
+++ b/app/views/content_type_objects/object_pages/grand_committee_proceeding.html.erb
@@ -1,0 +1,44 @@
+<% if Rails.env.development? %>
+  <div class="debug-panel" aria-hidden="true">
+    <%#= render 'content_type_objects/fragments/data', data: object.content_type_object_data, title: 'SOLR Data' %>
+    <%#= render 'content_type_objects/fragments/data', data: @ses_data, title: 'SES Data' %>
+  </div>
+<% end %>
+
+<%= render object.prelim_template, object: object %>
+<h1 class="reading-width">
+  <hr/>
+  <%= format_object_title(object.object_title, @ses_data) %>
+</h1>
+
+<% unless object.abstract_text.blank? %>
+  <div class="reading-width">
+    <%= raw format_html(object.abstract_text[:value], false) %>
+  </div>
+<% end %>
+
+<section class="reading-width">
+  <hr/>
+  <h2>Secondary information</h2>
+  <dl>
+    <%= render 'content_type_objects/fragments/type', type: object.type %>
+    <%= render 'content_type_objects/fragments/reference', reference: object.reference %>
+    <%= render 'content_type_objects/fragments/session', session: object.parliamentary_session %>
+    <%= render 'content_type_objects/fragments/departments', departments: object.departments %>
+    <%= render 'content_type_objects/fragments/corporate_author', author_label: 'Committee', author: object.corporate_author %>
+    <%= render 'content_type_objects/fragments/witnesses', witnesses: object.witnesses %>
+    <%= render 'content_type_objects/fragments/legislative_stage', legislative_stage: object.legislative_stage %>
+    <%= render 'content_type_objects/fragments/procedure', procedure: object.procedure %>
+    <%= render 'content_type_objects/fragments/place', place: object.place %>
+    <%= render 'content_type_objects/fragments/related_items', related_item_ids: object.related_item_ids %>
+    <%= render 'content_type_objects/fragments/contributions', contribution_ids: object.contribution_ids %>
+    <%= render 'content_type_objects/fragments/ec_documents', ec_documents: object.ec_documents %>
+    <%= render 'content_type_objects/fragments/notes', notes: object.notes %>
+    <%= render 'content_type_objects/fragments/pills', pills_heading: 'Subjects', pills: object.subjects %>
+    <%= render 'content_type_objects/fragments/legislation', legislation: object.legislation %>
+    <%= render 'content_type_objects/fragments/contains_statistics', contains_statistics: object.contains_statistics %>
+    <%= render 'content_type_objects/fragments/link', object: object %>
+  </dl>
+</section>
+
+<%= render '/content_type_objects/fragments/about_this_result', object: object %>

--- a/app/views/content_type_objects/object_pages/house_of_commons_paper.html.erb
+++ b/app/views/content_type_objects/object_pages/house_of_commons_paper.html.erb
@@ -1,0 +1,52 @@
+<% if Rails.env.development? %>
+  <div class="debug-panel" aria-hidden="true">
+    <%#= render 'content_type_objects/fragments/data', data: object.content_type_object_data, title: 'SOLR Data' %>
+    <%#= render 'content_type_objects/fragments/data', data: @ses_data, title: 'SES Data' %>
+  </div>
+<% end %>
+
+<%= render object.prelim_template, object: object %>
+<h1 class="reading-width">
+  <hr/>
+  <%= format_object_title(object.object_title, @ses_data) %>
+</h1>
+
+<% unless object.abstract_text.blank? %>
+  <p class="reading-width">
+    <%= object.abstract_text[:value] %>
+  </p>
+<% end %>
+
+<section class="reading-width">
+  <hr/>
+  <h2>Secondary information</h2>
+  <dl>
+    <%= render 'content_type_objects/fragments/type', type: object.type %>
+    <%= render 'content_type_objects/fragments/reference', reference: object.reference %>
+    <%= render 'content_type_objects/fragments/session', session: object.parliamentary_session %>
+    <%= render 'content_type_objects/fragments/coming_into_force', notes: object.coming_into_force, date: object.coming_into_force_date %>
+    <%= render 'content_type_objects/fragments/corporate_author', author_label: 'Author', author: object.corporate_author %>
+    <%= render 'content_type_objects/fragments/paper_type', paper_type: object.paper_type %>
+    <%= render 'content_type_objects/fragments/paper_procedure', procedure: object.paper_procedure, approval_days: object.procedure_scrutiny_period %>
+    <%= render 'content_type_objects/fragments/laying_authority', laying_authority: object.laying_authority %>
+    <%= render 'content_type_objects/fragments/laid_in_draft', laid_in_draft: object.is_laid_in_draft %>
+    <%= render 'content_type_objects/fragments/certified_categories', certified_categories: object.certified_categories, certified_date: object.certified_date %>
+    <%= render 'content_type_objects/fragments/referred_to', referred_to: object.referred_to %>
+    <%= render 'content_type_objects/fragments/considered_by_eu_si_committee', considered: object.is_considered_by_eu_si_committee %>
+    <%= render 'content_type_objects/fragments/considered_by_secondary_legislation_committee', considered: object.is_considered_by_secondary_legislation_committee %>
+    <%= render 'content_type_objects/fragments/reported_by_joint_committee', reported: object.is_reported_by_joint_committee %>
+    <%= render 'content_type_objects/fragments/related_items', related_item_ids: object.related_item_ids %>
+    <%= render 'content_type_objects/fragments/ec_documents', ec_documents: object.ec_documents %>
+    <%= render 'content_type_objects/fragments/contains_explanatory_memorandum', contains_em: object.contains_explanatory_memo %>
+    <%= render 'content_type_objects/fragments/contains_impact_assessment', contains_ia: object.contains_impact_assessment %>
+    <%= render 'content_type_objects/fragments/notes', notes: object.notes %>
+    <%= render 'content_type_objects/fragments/pills', pills_heading: 'Subjects', pills: object.subjects %>
+    <%= render 'content_type_objects/fragments/legislation', legislation: object.legislation %>
+    <%= render 'content_type_objects/fragments/library_location', commons: object.commons_library_location, lords: object.lords_library_location %>
+    <%= render 'content_type_objects/fragments/contains_statistics', contains_statistics: object.contains_statistics %>
+    <%= render 'content_type_objects/fragments/isbn', isbn: object.isbn %>
+    <%= render 'content_type_objects/fragments/link', object: object %>
+  </dl>
+</section>
+
+<%= render '/content_type_objects/fragments/about_this_result', object: object %>

--- a/app/views/content_type_objects/object_pages/parliamentary_committee.html.erb
+++ b/app/views/content_type_objects/object_pages/parliamentary_committee.html.erb
@@ -1,0 +1,35 @@
+<% if Rails.env.development? %>
+  <div class="debug-panel" aria-hidden="true">
+    <%#= render 'content_type_objects/fragments/data', data: object.content_type_object_data, title: 'SOLR Data' %>
+    <%#= render 'content_type_objects/fragments/data', data: @ses_data, title: 'SES Data' %>
+  </div>
+<% end %>
+
+<%= render object.prelim_template, object: object %>
+<h1 class="reading-width">
+  <hr/>
+  <%= format_object_title(object.object_title, @ses_data) %>
+</h1>
+
+<section class="reading-width">
+  <hr/>
+  <h2>Secondary information</h2>
+  <dl>
+    <%= render 'content_type_objects/fragments/type', type: object.type %>
+    <%= render 'content_type_objects/fragments/reference', reference: object.reference %>
+    <%= render 'content_type_objects/fragments/session', session: object.parliamentary_session %>
+    <%= render 'content_type_objects/fragments/witnesses', witnesses: object.witnesses %>
+    <%= render 'content_type_objects/fragments/paper_type', paper_type: object.paper_type %>
+    <%= render 'content_type_objects/fragments/related_items', related_item_ids: object.related_item_ids %>
+    <%= render 'content_type_objects/fragments/ec_documents', ec_documents: object.ec_documents %>
+    <%= render 'content_type_objects/fragments/notes', notes: object.notes %>
+    <%= render 'content_type_objects/fragments/pills', pills_heading: 'Subjects', pills: object.subjects %>
+    <%= render 'content_type_objects/fragments/legislation', legislation: object.legislation %>
+    <%= render 'content_type_objects/fragments/library_location', commons: object.commons_library_location, lords: object.lords_library_location %>
+    <%= render 'content_type_objects/fragments/contains_statistics', contains_statistics: object.contains_statistics %>
+    <%= render 'content_type_objects/fragments/isbn', isbn: object.isbn %>
+    <%= render 'content_type_objects/fragments/link', object: object %>
+  </dl>
+</section>
+
+<%= render '/content_type_objects/fragments/about_this_result', object: object %>

--- a/app/views/content_type_objects/object_pages/unprinted_command_paper.html.erb
+++ b/app/views/content_type_objects/object_pages/unprinted_command_paper.html.erb
@@ -1,0 +1,52 @@
+<% if Rails.env.development? %>
+  <div class="debug-panel" aria-hidden="true">
+    <%#= render 'content_type_objects/fragments/data', data: object.content_type_object_data, title: 'SOLR Data' %>
+    <%#= render 'content_type_objects/fragments/data', data: @ses_data, title: 'SES Data' %>
+  </div>
+<% end %>
+
+<%= render object.prelim_template, object: object %>
+<h1 class="reading-width">
+  <hr/>
+  <%= format_object_title(object.object_title, @ses_data) %>
+</h1>
+
+<% unless object.abstract_text.blank? %>
+  <p class="reading-width">
+    <%= object.abstract_text[:value] %>
+  </p>
+<% end %>
+
+<section class="reading-width">
+  <hr/>
+  <h2>Secondary information</h2>
+  <dl>
+    <%= render 'content_type_objects/fragments/type', type: object.type %>
+    <%= render 'content_type_objects/fragments/reference', reference: object.reference %>
+    <%= render 'content_type_objects/fragments/session', session: object.parliamentary_session %>
+    <%= render 'content_type_objects/fragments/coming_into_force', notes: object.coming_into_force, date: object.coming_into_force_date %>
+    <%= render 'content_type_objects/fragments/corporate_author', author_label: 'Author', author: object.corporate_author %>
+    <%= render 'content_type_objects/fragments/paper_type', paper_type: object.paper_type %>
+    <%= render 'content_type_objects/fragments/paper_procedure', procedure: object.paper_procedure, approval_days: object.procedure_scrutiny_period %>
+    <%= render 'content_type_objects/fragments/laying_authority', laying_authority: object.laying_authority %>
+    <%= render 'content_type_objects/fragments/laid_in_draft', laid_in_draft: object.is_laid_in_draft %>
+    <%= render 'content_type_objects/fragments/certified_categories', certified_categories: object.certified_categories, certified_date: object.certified_date %>
+    <%= render 'content_type_objects/fragments/referred_to', referred_to: object.referred_to %>
+    <%= render 'content_type_objects/fragments/considered_by_eu_si_committee', considered: object.is_considered_by_eu_si_committee %>
+    <%= render 'content_type_objects/fragments/considered_by_secondary_legislation_committee', considered: object.is_considered_by_secondary_legislation_committee %>
+    <%= render 'content_type_objects/fragments/reported_by_joint_committee', reported: object.is_reported_by_joint_committee %>
+    <%= render 'content_type_objects/fragments/related_items', related_item_ids: object.related_item_ids %>
+    <%= render 'content_type_objects/fragments/ec_documents', ec_documents: object.ec_documents %>
+    <%= render 'content_type_objects/fragments/contains_explanatory_memorandum', contains_em: object.contains_explanatory_memo %>
+    <%= render 'content_type_objects/fragments/contains_impact_assessment', contains_ia: object.contains_impact_assessment %>
+    <%= render 'content_type_objects/fragments/notes', notes: object.notes %>
+    <%= render 'content_type_objects/fragments/pills', pills_heading: 'Subjects', pills: object.subjects %>
+    <%= render 'content_type_objects/fragments/legislation', legislation: object.legislation %>
+    <%= render 'content_type_objects/fragments/library_location', commons: object.commons_library_location, lords: object.lords_library_location %>
+    <%= render 'content_type_objects/fragments/contains_statistics', contains_statistics: object.contains_statistics %>
+    <%= render 'content_type_objects/fragments/isbn', isbn: object.isbn %>
+    <%= render 'content_type_objects/fragments/link', object: object %>
+  </dl>
+</section>
+
+<%= render '/content_type_objects/fragments/about_this_result', object: object %>

--- a/app/views/content_type_objects/object_pages/unprinted_paper.html.erb
+++ b/app/views/content_type_objects/object_pages/unprinted_paper.html.erb
@@ -1,0 +1,52 @@
+<% if Rails.env.development? %>
+  <div class="debug-panel" aria-hidden="true">
+    <%#= render 'content_type_objects/fragments/data', data: object.content_type_object_data, title: 'SOLR Data' %>
+    <%#= render 'content_type_objects/fragments/data', data: @ses_data, title: 'SES Data' %>
+  </div>
+<% end %>
+
+<%= render object.prelim_template, object: object %>
+<h1 class="reading-width">
+  <hr/>
+  <%= format_object_title(object.object_title, @ses_data) %>
+</h1>
+
+<% unless object.abstract_text.blank? %>
+  <p class="reading-width">
+    <%= object.abstract_text[:value] %>
+  </p>
+<% end %>
+
+<section class="reading-width">
+  <hr/>
+  <h2>Secondary information</h2>
+  <dl>
+    <%= render 'content_type_objects/fragments/type', type: object.type %>
+    <%= render 'content_type_objects/fragments/reference', reference: object.reference %>
+    <%= render 'content_type_objects/fragments/session', session: object.parliamentary_session %>
+    <%= render 'content_type_objects/fragments/coming_into_force', notes: object.coming_into_force, date: object.coming_into_force_date %>
+    <%= render 'content_type_objects/fragments/corporate_author', author_label: 'Author', author: object.corporate_author %>
+    <%= render 'content_type_objects/fragments/paper_type', paper_type: object.paper_type %>
+    <%= render 'content_type_objects/fragments/paper_procedure', procedure: object.paper_procedure, approval_days: object.procedure_scrutiny_period %>
+    <%= render 'content_type_objects/fragments/laying_authority', laying_authority: object.laying_authority %>
+    <%= render 'content_type_objects/fragments/laid_in_draft', laid_in_draft: object.is_laid_in_draft %>
+    <%= render 'content_type_objects/fragments/certified_categories', certified_categories: object.certified_categories, certified_date: object.certified_date %>
+    <%= render 'content_type_objects/fragments/referred_to', referred_to: object.referred_to %>
+    <%= render 'content_type_objects/fragments/considered_by_eu_si_committee', considered: object.is_considered_by_eu_si_committee %>
+    <%= render 'content_type_objects/fragments/considered_by_secondary_legislation_committee', considered: object.is_considered_by_secondary_legislation_committee %>
+    <%= render 'content_type_objects/fragments/reported_by_joint_committee', reported: object.is_reported_by_joint_committee %>
+    <%= render 'content_type_objects/fragments/related_items', related_item_ids: object.related_item_ids %>
+    <%= render 'content_type_objects/fragments/ec_documents', ec_documents: object.ec_documents %>
+    <%= render 'content_type_objects/fragments/contains_explanatory_memorandum', contains_em: object.contains_explanatory_memo %>
+    <%= render 'content_type_objects/fragments/contains_impact_assessment', contains_ia: object.contains_impact_assessment %>
+    <%= render 'content_type_objects/fragments/notes', notes: object.notes %>
+    <%= render 'content_type_objects/fragments/pills', pills_heading: 'Subjects', pills: object.subjects %>
+    <%= render 'content_type_objects/fragments/legislation', legislation: object.legislation %>
+    <%= render 'content_type_objects/fragments/library_location', commons: object.commons_library_location, lords: object.lords_library_location %>
+    <%= render 'content_type_objects/fragments/contains_statistics', contains_statistics: object.contains_statistics %>
+    <%= render 'content_type_objects/fragments/isbn', isbn: object.isbn %>
+    <%= render 'content_type_objects/fragments/link', object: object %>
+  </dl>
+</section>
+
+<%= render '/content_type_objects/fragments/about_this_result', object: object %>

--- a/app/views/content_type_objects/preliminary_sentences/_command_paper.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_command_paper.haml
@@ -1,0 +1,30 @@
+%p.font-size-epsilon.reading-width
+  %span>= render 'content_type_objects/fragments/list', items: object.object_name, terminator: '', singular: true
+  - unless object.legislature.blank?
+    %span= " laid in the "
+    %span>= render 'content_type_objects/fragments/list', items: object.legislature, terminator: '', singular: false
+  - unless object.date.blank?
+    %span= " on "
+    %span>= format_date(object.date)
+  - unless object.member_name.blank?
+    %span= " by "
+    %span>= search_link(object.member_name)
+  - unless object.department.blank?
+    %span= " on behalf of the "
+    %span>= search_link(object.department)
+  %span= "."
+  - unless object.date_approved.blank?
+    %span= " It was approved by the House of Commons on "
+    %span>= format_date(object.date_approved)
+    %span= "."
+  - unless object.date_made.blank?
+    %span= " It was made on "
+    %span>= format_date(object.date_made)
+    %span= "."
+  - if object.date_withdrawn.blank?
+    - if object.is_withdrawn && object.is_withdrawn[:value]
+      %span= " It was subsequently withdrawn. "
+  - else
+    %span= " It was withdrawn on "
+    %span>= format_date(object.date_withdrawn)
+    %span= "."

--- a/app/views/content_type_objects/preliminary_sentences/_committee_proceeding.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_committee_proceeding.haml
@@ -1,0 +1,22 @@
+%p.font-size-epsilon.reading-width
+  %span>= render 'content_type_objects/fragments/list', items: object.object_name, terminator: '', singular: true
+  - unless object.date.blank?
+    %span= " on "
+    %span>= format_date(object.date)
+  - unless object.legislature.blank?
+    %span= ","
+    %span= " in the "
+    %span>= render 'content_type_objects/fragments/list', items: object.legislature, terminator: '', singular: false
+  - unless object.lead_members.blank?
+    %span= ","
+    %span= " led by "
+    %span>= render 'content_type_objects/fragments/list', items: object.lead_members, terminator: '', singular: false
+  %span= "."
+  - unless object.answering_members.blank?
+    %span= " The answering "
+    - if object.answering_members.size == 1
+      %span= " member was "
+    - else
+      %span= " members were "
+    %span>= render 'content_type_objects/fragments/list', items: object.answering_members, terminator: '', singular: false
+    %span= "."

--- a/app/views/content_type_objects/preliminary_sentences/_grand_committee_proceeding.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_grand_committee_proceeding.haml
@@ -1,0 +1,22 @@
+%p.font-size-epsilon.reading-width
+  %span>= render 'content_type_objects/fragments/list', items: object.object_name, terminator: '', singular: true
+  - unless object.date.blank?
+    %span= " on "
+    %span>= format_date(object.date)
+  - unless object.legislature.blank?
+    %span= ","
+    %span= " in the "
+    %span>= render 'content_type_objects/fragments/list', items: object.legislature, terminator: '', singular: false
+  - unless object.lead_members.blank?
+    %span= ","
+    %span= " led by "
+    %span>= render 'content_type_objects/fragments/list', items: object.lead_members, terminator: '', singular: false
+  %span= "."
+  - unless object.answering_members.blank?
+    %span= " The answering "
+    - if object.answering_members.size == 1
+      %span= " member was "
+    - else
+      %span= " members were "
+    %span>= render 'content_type_objects/fragments/list', items: object.answering_members, terminator: '', singular: false
+    %span= "."

--- a/app/views/content_type_objects/preliminary_sentences/_house_of_commons_paper.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_house_of_commons_paper.haml
@@ -1,0 +1,30 @@
+%p.font-size-epsilon.reading-width
+  %span>= render 'content_type_objects/fragments/list', items: object.object_name, terminator: '', singular: true
+  - unless object.legislature.blank?
+    %span= " laid in the "
+    %span>= render 'content_type_objects/fragments/list', items: object.legislature, terminator: '', singular: false
+  - unless object.date.blank?
+    %span= " on "
+    %span>= format_date(object.date)
+  - unless object.member_name.blank?
+    %span= " by "
+    %span>= search_link(object.member_name)
+  - unless object.department.blank?
+    %span= " on behalf of the "
+    %span>= search_link(object.department)
+  %span= "."
+  - unless object.date_approved.blank?
+    %span= " It was approved by the House of Commons on "
+    %span>= format_date(object.date_approved)
+    %span= "."
+  - unless object.date_made.blank?
+    %span= " It was made on "
+    %span>= format_date(object.date_made)
+    %span= "."
+  - if object.date_withdrawn.blank?
+    - if object.is_withdrawn && object.is_withdrawn[:value]
+      %span= " It was subsequently withdrawn. "
+  - else
+    %span= " It was withdrawn on "
+    %span>= format_date(object.date_withdrawn)
+    %span= "."

--- a/app/views/content_type_objects/preliminary_sentences/_parliamentary_committee.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_parliamentary_committee.haml
@@ -1,0 +1,12 @@
+%p.font-size-epsilon.reading-width
+  %span>= render 'content_type_objects/fragments/list', items: object.object_name, terminator: '', singular: true
+  - unless object.legislature.blank?
+    %span= " reported in the "
+    %span>= render 'content_type_objects/fragments/list', items: object.legislature, terminator: '', singular: false
+  - unless object.date.blank?
+    %span= " on "
+    %span>= format_date(object.date)
+  - unless object.corporate_author.blank?
+    %span= " from the "
+    %span>= render 'content_type_objects/fragments/list', items: object.corporate_author, terminator: '', singular: false
+  %span= "."

--- a/app/views/content_type_objects/preliminary_sentences/_unprinted_command_paper.haml
+++ b/app/views/content_type_objects/preliminary_sentences/_unprinted_command_paper.haml
@@ -1,0 +1,30 @@
+%p.font-size-epsilon.reading-width
+  %span>= render 'content_type_objects/fragments/list', items: object.object_name, terminator: '', singular: true
+  - unless object.legislature.blank?
+    %span= " laid in the "
+    %span>= render 'content_type_objects/fragments/list', items: object.legislature, terminator: '', singular: false
+  - unless object.date.blank?
+    %span= " on "
+    %span>= format_date(object.date)
+  - unless object.member_name.blank?
+    %span= " by "
+    %span>= search_link(object.member_name)
+  - unless object.department.blank?
+    %span= " on behalf of the "
+    %span>= search_link(object.department)
+  %span= "."
+  - unless object.date_approved.blank?
+    %span= " It was approved by the House of Commons on "
+    %span>= format_date(object.date_approved)
+    %span= "."
+  - unless object.date_made.blank?
+    %span= " It was made on "
+    %span>= format_date(object.date_made)
+    %span= "."
+  - if object.date_withdrawn.blank?
+    - if object.is_withdrawn && object.is_withdrawn[:value]
+      %span= " It was subsequently withdrawn. "
+  - else
+    %span= " It was withdrawn on "
+    %span>= format_date(object.date_withdrawn)
+    %span= "."

--- a/app/views/search/results/_house_of_commons_paper.erb
+++ b/app/views/search/results/_house_of_commons_paper.erb
@@ -1,0 +1,84 @@
+<div class="result-item pb-3">
+  <div class="row py-1 title">
+    <div class="col">
+      <%= link_to(format_object_title(object.object_title, @ses_data), object_show_url(object: object.object_uri[:value])) %>
+    </div>
+  </div>
+
+  <div class="row py-1">
+    <div class="col primary-person">
+      <%= render 'search/results/item_details/laid_by', laid_by: object.member_name, label: 'Laid by' %>
+    </div>
+    <div class="col secondary-person"></div>
+    <div class="col primary-group">
+      <%= render 'search/results/item_details/departments', departments: object.departments, label: 'Department' %>
+    </div>
+  </div>
+
+  <div class="row py-1">
+    <div class="col type">
+      <%= render 'search/results/item_details/subtype_or_type', subtype: object.subtypes, type: object.type %>
+    </div>
+    <div class="col status"></div>
+    <div <%= 'hidden' unless params[:show_detailed] == "true" %>>
+      <div class="col secondary-group">
+        <%= render 'search/results/item_details/corporate_author', corporate_author: object.corporate_author, label: 'Author' %>
+      </div>
+    </div>
+  </div>
+
+  <div <%= 'hidden' unless params[:show_detailed] == "true" %>>
+    <div class="row py-1">
+      <div class="col legislative-stage"></div>
+      <div class="col procedure">
+        <%= render 'search/results/item_details/paper_procedure', procedure: object.paper_procedure %>
+      </div>
+    </div>
+
+    <div class="row py-1">
+      <div class="col specific-date-1">
+        <%= render 'search/results/item_details/date_laid', date_laid: object.date_laid %>
+      </div>
+      <div class="col specific-date-2">
+        <%= render 'search/results/item_details/date_of_order_to_print', date_of_order_to_print: object.date_of_order_to_print %>
+      </div>
+      <div class="col specific-date-3">
+        <%= render 'search/results/item_details/date_withdrawn', date_withdrawn: object.date_withdrawn %>
+      </div>
+      <div class="col specific-date-4"></div>
+    </div>
+
+    <%= render 'search/results/item_details/legislation', legislation: object.legislation unless object.legislation.blank? %>
+  </div>
+
+  <%= render 'search/results/item_details/notes', notes: object.notes unless object.notes.blank? %>
+
+  <div <%= 'hidden' unless params[:show_detailed] == "true" %>>
+    <%= render 'search/results/item_details/subjects', subjects: object.subjects unless object.subjects.blank? %>
+  </div>
+
+  <div <%= 'hidden' unless params[:show_detailed] == "true" %>>
+    <% unless object.commons_library_location.blank? && object.lords_library_location.blank? %>
+      <div class="row py-1">
+        <div class="col commons-library-location">
+          <%= render 'search/results/item_details/commons_library_location', location: object.commons_library_location unless object.commons_library_location.blank? %>
+        </div>
+        <div class="col lords-library-location">
+          <%= render 'search/results/item_details/lords_library_location', location: object.lords_library_location unless object.lords_library_location.blank? %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="row py-1">
+    <div class="col significant-date">
+      <%= render 'search/results/item_details/date', date: object.standard_date %>
+    </div>
+    <div class="col reference">
+      <%= render 'search/results/item_details/reference', reference: object.standard_reference %>
+    </div>
+    <div class="col house">
+      <%= render 'search/results/item_details/legislature', legislature: object.legislature %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Remove supported types from content_type_object_class
- Add missing partials following object page / prelim sentence path change (now generated from class name)