### PR TITLE
Filter out INT terms

### DIFF
--- a/app/services/ses_data_processor.rb
+++ b/app/services/ses_data_processor.rb
@@ -34,7 +34,7 @@ class SesDataProcessor
 
     terms.each do |term|
       # skip topic terms
-      next if term_is_topic_term(term)
+      next if term_is_of_unwanted_class(term)
 
       term_matches_query = false
       term_hash = populate_term_hash(term)
@@ -96,10 +96,13 @@ class SesDataProcessor
   end
 
   ##
-  # Identify topic terms (unwanted) by class string
-  def term_is_topic_term(term)
+  # Identify topic terms and intranet terms (unwanted) by class strings
+  def term_is_of_unwanted_class(term)
     # With SES v3, TPG will be the only class, whereas with SES v5 we need to check 'classes' which can contain multiple values
-    term.dig("term", "class") == "TPG" || term.dig("term", "classes")&.include?("TPG")
+    term.dig("term", "class") == "TPG" ||
+      term.dig("term", "classes")&.include?("TPG") ||
+      term.dig("term", "class") == "INT" ||
+      term.dig("term", "classes")&.include?("INT")
   end
 
   ##

--- a/spec/fixtures/ses_search_service_example_int.json
+++ b/spec/fixtures/ses_search_service_example_int.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "tbdb": "disp_taxonomy",
+    "expand_hierarchy": "0",
+    "query": "housing",
+    "service": "search",
+    "template": "service.json"
+  },
+  "terms": [
+    {
+      "term": {
+        "name": "Housing",
+        "id": "95629",
+        "zid": "OMIIN374695665II410059274qKWucoz5vHS4miNNDFbE",
+        "class": "INT",
+        "freq": "0",
+        "facets": [
+          {
+            "id": "95475",
+            "name": "Taxonomy"
+          }
+        ],
+        "attributes": {
+          "Do not use for concept mapping": "1"
+        },
+        "metadata": {},
+        "src": "1",
+        "rank": "2",
+        "percentage": "49",
+        "weight": "10.6175",
+        "index": "disp_taxonomy",
+        "displayName": "Housing",
+        "foundByNPT": "0",
+        "lastUpdatedDate": "20250202164215",
+        "createdDate": "20100514065421",
+        "creator": "admin",
+        "updator": "userx",
+        "status": "Approved",
+        "documents": "0",
+        "hierarchy": [
+          {
+            "typeId": "1",
+            "qty": "1",
+            "name": "Broader Term",
+            "abbr": "BT"
+          },
+          {
+            "typeId": "1",
+            "qty": "10",
+            "name": "Narrower Term",
+            "abbr": "NT"
+          }
+        ],
+        "equivalence": [
+          {
+            "typeId": "3",
+            "qty": "1",
+            "name": "Use For",
+            "abbr": "UF",
+            "fields": [
+              {
+                "field": {
+                  "name": "Squatting",
+                  "id": "51631",
+                  "zid": "OMII1621104769IIN1531896557KKORKs3GuOrVUsXkFD6h",
+                  "freq": "0"
+                }
+              }
+            ]
+          }
+        ],
+        "paths": [
+          {
+            "path": [
+              {
+                "field": {
+                  "name": "Taxonomy",
+                  "id": "95475",
+                  "zid": "OMII0II1490289559",
+                  "class": "INT",
+                  "freq": "0",
+                  "facets": [
+                    {
+                      "id": "95475",
+                      "name": "Taxonomy"
+                    }
+                  ]
+                }
+              },
+              {
+                "field": {
+                  "name": "Housing and planning",
+                  "id": "95631",
+                  "zid": "OMII627204670IIN97677081976hC980H0X00jODdRwxn",
+                  "class": "INT",
+                  "freq": "0",
+                  "facets": [
+                    {
+                      "id": "95475",
+                      "name": "Taxonomy"
+                    }
+                  ]
+                }
+              },
+              {
+                "field": {
+                  "name": "Housing",
+                  "id": "95629",
+                  "zid": "OMIIN374695665II410059274qKWucoz5vHS4miNNDFbE",
+                  "class": "INT",
+                  "freq": "0",
+                  "facets": [
+                    {
+                      "id": "95475",
+                      "name": "Taxonomy"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/services/ses_query_spec.rb
+++ b/spec/services/ses_query_spec.rb
@@ -89,5 +89,15 @@ RSpec.describe 'SesQuery' do
         expect(ses_query.data).to eq([])
       end
     end
+
+    context 'where SES returns an intranet term result' do
+      let!(:mock_response) { JSON.parse(File.read('spec/fixtures/ses_search_service_example_int.json')) }
+      let!(:input_data) { { value: 'housing' } }
+      let!(:formatted_query) { URI("https://api.test.url/ses?tbdb=test_tbdb&service=search&template=service.json&query=housing") }
+
+      it 'does not return the topic' do
+        expect(ses_query.data).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
- Add an additional filtering step to SesDataProcessor to remove class="INT" terms from retrieved SES data, which were interfering during query expansion with SESv5.
- Add a test for this filtering step. Nb. test data used is TPG response with classes replaced with INT, as the structure is the only thing that matters for testing purposes.