### PR TITLE
Fix query expansion for date ranges

### DIFF
--- a/app/services/query_expander.rb
+++ b/app/services/query_expander.rb
@@ -122,11 +122,19 @@ class QueryExpander
   end
 
   def process_specified_field_no_expansion_token(value)
-    # delete unwanted []; expand fields using blank SES data
-    search_term = value.partition(":").last.delete_prefix("[").delete_suffix("]")
     field_name = value.partition(":").first
-    expanded_fields = field_expander.new(field_name).expand_fields
 
+    # This is also used for date ranges, so we need to differentiate between the two
+    if field_name == 'date' || field_name.last(3) == '_dt'
+      # this is a date range query
+      search_term = value.partition(":").last
+    else
+      # this is a request not to expand the provided term
+      # delete unwanted []; expand fields using blank SES data
+      search_term = value.partition(":").last.delete_prefix("[").delete_suffix("]")
+    end
+
+    expanded_fields = field_expander.new(field_name).expand_fields
     term_expander.new(expanded_fields: expanded_fields, search_term: search_term).expand_terms
   end
 

--- a/spec/services/query_expander_spec.rb
+++ b/spec/services/query_expander_spec.rb
@@ -156,41 +156,111 @@ RSpec.describe 'QueryExpander' do
     end
 
     context "where the term is a phrase wrapped in square brackets with a specified field" do
-      let(:search_query) { ["subject:[housing crisis]"] }
-      it 'expands the field only' do
-        # tokeniser is initialised with the query string
-        expect(tokeniser_test_class).to receive(:new).with(["subject:[housing crisis]"])
+      context 'for a date range query' do
+        context 'the "date" alias' do
+          let(:search_query) { ["date:[2026-04-30T00:00:00Z TO *]"] }
+          it 'expands the date alias but leaves the date range unmodified' do
+            # tokeniser is initialised with the query string
+            expect(tokeniser_test_class).to receive(:new).with(["date:[2026-04-30T00:00:00Z TO *]"])
 
-        # tokeniser instance receives call to tokenise
-        expect(tokeniser_test_instance).to receive(:tokenise).and_return([[:specified_field_no_expansion, "subject:[housing crisis]"]])
+            # tokeniser instance receives call to tokenise
+            expect(tokeniser_test_instance).to receive(:tokenise).and_return([[:specified_field_no_expansion, 'date:[2026-04-30T00:00:00Z TO *]']])
 
-        # SES query class is not initialised
-        expect(ses_test_class).not_to receive(:new)
+            # field expander class is initialised with the alias
+            expect(field_expander_test_class).to receive(:new).with('date')
 
-        # SES query instance does not receive call for data
-        expect(ses_test_instance).not_to receive(:data)
+            # field expander instance receives call to expand_fields
+            expect(field_expander_test_instance).to receive(:expand_fields).and_return(expanded_fields)
 
-        # field expander class is initialised with the field name (only)
-        expect(field_expander_test_class).to receive(:new).with('subject')
+            # the term expander is initialised with the result of the field expansion & blank ses data, as well as the search
+            # term. Note that the square brackets required by the range query syntax remain intact.
+            expect(term_expander_test_class).to receive(:new).with(expanded_fields: expanded_fields, search_term: "[2026-04-30T00:00:00Z TO *]")
 
-        # field expander instance receives call to expand_fields
-        expect(field_expander_test_instance).to receive(:expand_fields).and_return(expanded_fields)
+            # term expander receives call to expand terms
+            expect(term_expander_test_instance).to receive(:expand_terms).and_return('processed tokens')
 
-        # the term expander is initialised with the result of the field expansion & blank ses data, as well as the search
-        # term
-        expect(term_expander_test_class).to receive(:new).with(expanded_fields: expanded_fields, search_term: "housing crisis")
+            # the term combiner is initialised with the response from expand terms in an array
+            expect(term_combiner_test_class).to receive(:new).with(['processed tokens'])
 
-        # term expander receives call to expand terms
-        expect(term_expander_test_instance).to receive(:expand_terms).and_return('processed tokens')
+            # the term combiner recieves call to combine the terms
+            expect(term_combiner_test_instance).to receive(:combine_terms).and_return("combined terms")
 
-        # the term combiner is initialised with the response from expand terms in an array
-        expect(term_combiner_test_class).to receive(:new).with(['processed tokens'])
+            # the method returns the result from the term combiner
+            expect(query_expander.expand_query).to eq("combined terms")
+          end
+        end
+        context 'a date field name ending _dt' do
+          let(:search_query) { ["anything_dt:[2026-04-30T00:00:00Z TO *]"] }
+          it 'handles _dt fields by expecting a date range, which is then left unmodified' do
+            # tokeniser is initialised with the query string
+            expect(tokeniser_test_class).to receive(:new).with(["anything_dt:[2026-04-30T00:00:00Z TO *]"])
 
-        # the term combiner recieves call to combine the terms
-        expect(term_combiner_test_instance).to receive(:combine_terms).and_return("combined terms")
+            # tokeniser instance receives call to tokenise
+            expect(tokeniser_test_instance).to receive(:tokenise).and_return([[:specified_field_no_expansion, 'anything_dt:[2026-04-30T00:00:00Z TO *]']])
 
-        # the method returns the result from the term combiner
-        expect(query_expander.expand_query).to eq("combined terms")
+            # field expander class is initialised with the field name (only)
+            expect(field_expander_test_class).to receive(:new).with('anything_dt')
+
+            # field expander instance receives call to expand_fields
+            expect(field_expander_test_instance).to receive(:expand_fields).and_return(expanded_fields)
+
+            # the term expander is initialised with the result of the field expansion & blank ses data, as well as the search
+            # term. Note that the square brackets required by the range query syntax remain intact.
+            expect(term_expander_test_class).to receive(:new).with(expanded_fields: expanded_fields, search_term: "[2026-04-30T00:00:00Z TO *]")
+
+            # term expander receives call to expand terms
+            expect(term_expander_test_instance).to receive(:expand_terms).and_return('processed tokens')
+
+            # the term combiner is initialised with the response from expand terms in an array
+            expect(term_combiner_test_class).to receive(:new).with(['processed tokens'])
+
+            # the term combiner recieves call to combine the terms
+            expect(term_combiner_test_instance).to receive(:combine_terms).and_return("combined terms")
+
+            # the method returns the result from the term combiner
+            expect(query_expander.expand_query).to eq("combined terms")
+          end
+        end
+
+      end
+
+      context 'for non-date ranges' do
+        let(:search_query) { ["subject:[housing crisis]"] }
+        it 'expands the field only' do
+          # tokeniser is initialised with the query string
+          expect(tokeniser_test_class).to receive(:new).with(["subject:[housing crisis]"])
+
+          # tokeniser instance receives call to tokenise
+          expect(tokeniser_test_instance).to receive(:tokenise).and_return([[:specified_field_no_expansion, "subject:[housing crisis]"]])
+
+          # SES query class is not initialised
+          expect(ses_test_class).not_to receive(:new)
+
+          # SES query instance does not receive call for data
+          expect(ses_test_instance).not_to receive(:data)
+
+          # field expander class is initialised with the field name (only)
+          expect(field_expander_test_class).to receive(:new).with('subject')
+
+          # field expander instance receives call to expand_fields
+          expect(field_expander_test_instance).to receive(:expand_fields).and_return(expanded_fields)
+
+          # the term expander is initialised with the result of the field expansion & blank ses data, as well as the search
+          # term - note that the square brackets have been stripped from the search term
+          expect(term_expander_test_class).to receive(:new).with(expanded_fields: expanded_fields, search_term: "housing crisis")
+
+          # term expander receives call to expand terms
+          expect(term_expander_test_instance).to receive(:expand_terms).and_return('processed tokens')
+
+          # the term combiner is initialised with the response from expand terms in an array
+          expect(term_combiner_test_class).to receive(:new).with(['processed tokens'])
+
+          # the term combiner recieves call to combine the terms
+          expect(term_combiner_test_instance).to receive(:combine_terms).and_return("combined terms")
+
+          # the method returns the result from the term combiner
+          expect(query_expander.expand_query).to eq("combined terms")
+        end
       end
     end
 


### PR DESCRIPTION
- Add some logic to the processing of tokens that look like "this:[term]" to differentiate between searches where the user doesn't want to expand the term using SES ("title_t:[horses]") and searches for date ranges ("date:[2000-01-01 TO *]"). In the latter case, we don't want to strip the square brackets out of the search term, as they're required for Solr to understand it's a range query.