### PR TITLE
Line spacing for prelim sentences

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -77,3 +77,7 @@ blockquote p:last-of-type:after {
     content: close-quote;
     color: #717171;
 }
+
+.font-size-epsilon {
+    line-height: 1.25;
+}


### PR DESCRIPTION
Use line height 1.25 for larger font size (design system class 'font-size-epsilon') used in preliminary sentences